### PR TITLE
BUG FIX if the `objItem.Name` is not a string.

### DIFF
--- a/listComPorts.vbs
+++ b/listComPorts.vbs
@@ -42,9 +42,11 @@ Function GetComPorts()
         set objRgx = CreateObject("vbScript.RegExp")
         strDevName = objItem.Name
         objRgx.Pattern = "COM[0-9]+"
-        set objRegMatches = objRgx.Execute(strDevName)
-        if objRegMatches.Count = 1 then
-            portList.Add objRegMatches.Item(0).Value, objItem 
+        if vbString = VarType(strDevName) then
+            set objRegMatches = objRgx.Execute(strDevName)
+            if objRegMatches.Count = 1 then
+                portList.Add objRegMatches.Item(0).Value, objItem 
+            end if
         end if
     Next
     set GetComPorts = portList


### PR DESCRIPTION
I found the `Name` field of the `objItem` may not always be a string, it is an array sometimes. And the script will be crashed in this situation. So I add a type checking just before calling the regex matching to fix this bug.